### PR TITLE
fix: fix typos in Cache and DicomFuseHelperTest classes

### DIFF
--- a/src/main/java/com/google/dicomwebfuse/entities/cache/Cache.java
+++ b/src/main/java/com/google/dicomwebfuse/entities/cache/Cache.java
@@ -270,8 +270,8 @@ public class Cache {
     // milliseconds in Java 8. That's why, to avoid incorrect isBefore(instantNow) results in
     // cases where less than a millisecond has passed equals(instantNow) were included.
     Instant instantNow = Instant.now();
-    return cachedSeries.getSeriesCacheTime().isBefore(Instant.now()) ||
-        cachedStudy.getStudyCacheTime().equals(instantNow);
+    return cachedSeries.getSeriesCacheTime().isBefore(instantNow) ||
+        cachedSeries.getSeriesCacheTime().equals(instantNow);
   }
 
   public boolean isDicomStoreNotExist(DicomPath dicomPath) {


### PR DESCRIPTION
- Fixed typos in the Cache and DicomFuseHelperTest classes, which could cause incorrect behavior in the cache and fail the unit test
- Added additional checks to the DicomFuseHelperTest