### PR TITLE
feat: create a DICOM Store by creating a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ navigate through folders.
 *   Upload a file in the Series folder (drag and drop).
 *   Delete a *.dcm file in the Series folder.
 *   Overwrite existing file.
+*   Create DICOM Store folder(only on Linux). If you try to create a folder at a 
+    different level, you will get the error:  
+    _Error creating directory path_to_the_directory: Operation not permitted_
 *   Replace operation (drag and drop) is not supported.
 
 > Note: to get better performance, you must upload files to DICOM Store folder, and
@@ -130,9 +133,9 @@ navigate through folders.
 *   cp - copy **only instances files** (not folders) to another DICOM store or
     to a local computer.
 *   rm - delete instances files.
-*   mkdir - is not supported. If you try to create a new folder, you will get
-    the error: \
-    _mkdir: cannot create directory ‘new-folder’: Function not implemented._
+*   Create DICOM Store folder. If you try to create a folder at a different level, 
+    you will get the error:  
+    _mkdir: cannot create directory ‘new_folder’: Operation not permitted_
 *   mv - is not supported.
 
 Any reading use cases can be used, such as de-identification or manual editing

--- a/src/main/java/com/google/dicomwebfuse/dao/Constants.java
+++ b/src/main/java/com/google/dicomwebfuse/dao/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
   static final String PARAM_STUDY_ID = "StudyInstanceUID";
   static final String PARAM_SERIES_ID = "SeriesInstanceUID";
   static final String PARAM_INSTANCE_ID = "SOPInstanceUID";
+  static final String PARAM_DICOM_STORE_ID = "dicomStoreId";
   static final String VALUE_PARAM_STUDY_INSTANCE_UID = "0020000D";
   static final String VALUE_PARAM_SERIES_INSTANCE_UID = "0020000E";
   public static final Integer VALUE_PARAM_MAX_LIMIT_FOR_STUDY = 5000;

--- a/src/main/java/com/google/dicomwebfuse/dao/FuseDao.java
+++ b/src/main/java/com/google/dicomwebfuse/dao/FuseDao.java
@@ -36,4 +36,5 @@ public interface FuseDao {
   void downloadInstance(QueryBuilder queryBuilder) throws DicomFuseException;
   void uploadInstance(QueryBuilder queryBuilder) throws DicomFuseException;
   void deleteInstance(QueryBuilder queryBuilder) throws DicomFuseException;
+  void createDicomStore(QueryBuilder queryBuilder) throws DicomFuseException;
 }

--- a/src/main/java/com/google/dicomwebfuse/dao/FuseDaoHelper.java
+++ b/src/main/java/com/google/dicomwebfuse/dao/FuseDaoHelper.java
@@ -222,6 +222,13 @@ public class FuseDaoHelper {
     fuseDao.deleteInstance(queryBuilder);
   }
 
+  public static void createDicomStore(FuseDao fuseDao, CloudConf cloudConf, DicomPath dicomPath)
+      throws DicomFuseException {
+    QueryBuilder queryBuilder = QueryBuilder.forConfiguration(cloudConf)
+        .setDicomStoreId(dicomPath.getDicomStoreId());
+    fuseDao.createDicomStore(queryBuilder);
+  }
+
   private FuseDaoHelper() {
   }
 }

--- a/src/main/java/com/google/dicomwebfuse/fuse/DicomFuse.java
+++ b/src/main/java/com/google/dicomwebfuse/fuse/DicomFuse.java
@@ -209,6 +209,19 @@ public class DicomFuse extends FuseStubFS {
   }
 
   @Override
+  public int mkdir(String path, long mode) {
+    LOGGER.debug("mkdir " + path);
+    try {
+      DicomPath dicomPath = dicomPathParser.parsePath(path);
+      dicomFuseHelper.createDicomStoreInDataset(dicomPath);
+    } catch (DicomFuseException e) {
+      LOGGER.error("mkdir error", e);
+      return -ErrorCodes.EPERM();
+    }
+    return 0;
+  }
+
+  @Override
   public int statfs(String path, Statvfs stbuf) {
     if (os == WINDOWS || os == DARWIN) {
       if ("/".equals(path)) {

--- a/src/main/java/com/google/dicomwebfuse/fuse/DicomFuseHelper.java
+++ b/src/main/java/com/google/dicomwebfuse/fuse/DicomFuseHelper.java
@@ -14,6 +14,7 @@
 
 package com.google.dicomwebfuse.fuse;
 
+import static com.google.dicomwebfuse.entities.DicomPathLevel.DICOM_STORE;
 import static com.google.dicomwebfuse.entities.DicomPathLevel.SERIES;
 import static com.google.dicomwebfuse.entities.DicomPathLevel.STUDY;
 import static com.google.dicomwebfuse.fuse.FuseConstants.DCM_EXTENSION;
@@ -434,6 +435,20 @@ class DicomFuseHelper {
     LOGGER.info("Instance was deleted - " + dicomPath);
     downloadCacher.removePath(dicomPath);
     invalidateDicomStoreCache(dicomPath);
+  }
+
+  void createDicomStoreInDataset(DicomPath dicomPath) throws DicomFuseException {
+    if (dicomPath.getDicomPathLevel() == DICOM_STORE) {
+      FuseDaoHelper.createDicomStore(parameters.getFuseDAO(), parameters.getCloudConf(), dicomPath);
+      String dicomStoreId = dicomPath.getDicomStoreId();
+      DicomStore dicomStore = new DicomStore();
+      dicomStore.setDicomStoreId(dicomStoreId);
+      CachedDicomStore newCachedDicomStore = new CachedDicomStore(dicomStore);
+      cache.getCachedDicomStores().put(dicomStoreId, newCachedDicomStore);
+      LOGGER.info("DICOM Store was created - " + dicomPath);
+    } else {
+      throw new DicomFuseException("You can only create DICOM Store folder");
+    }
   }
 
   private void updateDicomStoresInDataset() throws DicomFuseException {

--- a/src/test/java/com/google/dicomwebfuse/TestUtils.java
+++ b/src/test/java/com/google/dicomwebfuse/TestUtils.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -255,6 +256,16 @@ public class TestUtils {
   }
 
   /**
+   * Generates CloseableHttpResponse.
+   *
+   * @param statusCode Http response code
+   * @return response object
+   */
+  public static CloseableHttpResponse prepareHttpResponse(int statusCode) {
+    return prepareHttpResponse(statusCode, Collections.emptyList());
+  }
+
+  /**
    * Generates CloseableHttpResponse with multiple entities.
    *
    * @param statusCode Http response code
@@ -270,7 +281,8 @@ public class TestUtils {
 
     if (httpEntities.size() == 1) {
       Mockito.when(closeableHttpResponse.getEntity()).thenReturn(httpEntities.get(0));
-    } else {
+    }
+    if (httpEntities.size() > 1) {
       BasicHttpEntity[] array = new BasicHttpEntity[httpEntities.size() - 1];
       array = httpEntities.toArray(array);
       BasicHttpEntity[] entities = Arrays.copyOfRange(array, 1, array.length);


### PR DESCRIPTION
[#35]
- This feature works in the graphical and command-line interfaces on Linux, but on Windows and macOS only on the command line. Windows and macOS try to create a "New folder"(DICOM Store) by default in the graphical interface when a user tries to create a new folder.
- Added unit tests for the new feature