### PR TITLE
Upgrade log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.github.serceman</groupId>
       <artifactId>jnr-fuse</artifactId>
-      <version>0.5.2.1</version>
+      <version>0.5.7</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -54,12 +54,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.13.2</version>
+      <version>2.15.0/version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.2</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0/version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/com/google/dicomwebfuse/dao/FuseDaoImpl.java
+++ b/src/main/java/com/google/dicomwebfuse/dao/FuseDaoImpl.java
@@ -403,7 +403,7 @@ public class FuseDaoImpl implements FuseDao {
 
   private void checkStatusCode(CloseableHttpResponse response, URI uri) throws DicomFuseException {
     int statusCode = response.getStatusLine().getStatusCode();
-    if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
+    if (statusCode != HttpStatusCodes.STATUS_CODE_OK || statusCode != HttpStatusCodes.STATUS_CODE_NO_CONTENT) {
       throw new DicomFuseException("Failed HTTP " + response.getStatusLine() + " " + uri,
           statusCode);
     }


### PR DESCRIPTION
Upgrade log4j due to vulnerabilities in versions before 2.15

Additionally try to fix presubmit failure from the automated update (https://github.com/GoogleCloudPlatform/healthcare-api-dicom-fuse/pull/55) which couldn't find jnr-fuse 0.5.2